### PR TITLE
Auth issues with long cr poll

### DIFF
--- a/benchmark_runner/oadp/oadp_workloads.py
+++ b/benchmark_runner/oadp/oadp_workloads.py
@@ -1218,7 +1218,7 @@ class OadpWorkloads(WorkloadsOperations):
                 if state in ['Completed', 'Failed', 'PartiallyFailed', 'Deleted', 'FinalizingPartiallyFailed', 'WaitingForPluginOperationsPartiallyFailed' ]:
                     logger.info(f"::: INFO ::: wait_for_condition_of_oadp_cr: CR current status: of {cr_name} state: {state} in ['Completed', 'Failed', 'PartiallyFailed', 'FinalizingPartiallyFailed', 'WaitingForPluginOperationsPartiallyFailed']")
                     return True
-                if "couldn't get current server" in state or 'forbidden' in state:
+                if "couldn't get current server" in state or 'forbidden' in state or 'Unauthorized' in state:
                     logger.warning("### Warning ### Unauthorized error detected during CR poll wait_for_condition_of_cr issuing login attempt ")
                     logged_in = self.oc_log_in()
                     if not logged_in:

--- a/benchmark_runner/oadp/oadp_workloads.py
+++ b/benchmark_runner/oadp/oadp_workloads.py
@@ -1218,7 +1218,7 @@ class OadpWorkloads(WorkloadsOperations):
                 if state in ['Completed', 'Failed', 'PartiallyFailed', 'Deleted', 'FinalizingPartiallyFailed', 'WaitingForPluginOperationsPartiallyFailed' ]:
                     logger.info(f"::: INFO ::: wait_for_condition_of_oadp_cr: CR current status: of {cr_name} state: {state} in ['Completed', 'Failed', 'PartiallyFailed', 'FinalizingPartiallyFailed', 'WaitingForPluginOperationsPartiallyFailed']")
                     return True
-                if "couldn't get current server" in state or 'forbidden' in state or 'Unauthorized' in state:
+                if state in ["couldn't get current server", "forbidden", 'Unauthorized']:
                     logger.warning("### Warning ### Unauthorized error detected during CR poll wait_for_condition_of_cr issuing login attempt ")
                     logged_in = self.oc_log_in()
                     if not logged_in:


### PR DESCRIPTION
## Type of change
Note: Fill **x** in []
- [ ] bug
- [x ] enhancement
- [ ] documentation
- [ ] dependencies

## Description

CR polling can fail due to auth expiring.
This will check for instances of auth expiring and re-authenticate.
The fix was tested with auth expiring simulated mid-cr check.

    Updated wait_for_cr to check for logged out session
    
    Will check for
    - couldn't get server
    - forbidden
    - Unathorized
    
    If found will attempt oc log in, and then continue polling

   
    Fix for Issue #12 Benchmark Runner CR polling doesn't handle auth failures during long runs



## For security reasons, all pull requests need to be approved first before running any automated CI
